### PR TITLE
ONB-201: Implement keyword generator

### DIFF
--- a/src/pages/keyword-generator/KeywordGenerator.vue
+++ b/src/pages/keyword-generator/KeywordGenerator.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 const userInput = ref('');
 const generatedKeywords = ref({
@@ -8,6 +8,20 @@ const generatedKeywords = ref({
     threeGram: [],
 });
 const hasGenerated = ref(false);
+const keywordSections = computed(() => [
+    {
+        title: '1-Gram',
+        keywords: generatedKeywords.value.oneGram,
+    },
+    {
+        title: '2-Gram',
+        keywords: generatedKeywords.value.twoGram,
+    },
+    {
+        title: '3-Gram',
+        keywords: generatedKeywords.value.threeGram,
+    },
+]);
 
 const cleanInput = (input) => input
     .toLowerCase()
@@ -55,30 +69,10 @@ const generateKeywords = () => {
         </button>
 
         <section v-if="hasGenerated" class="ma-keyword-results" aria-live="polite">
-            <div>
-                <h2>1-Gram</h2>
-                <ul v-if="generatedKeywords.oneGram.length">
-                    <li v-for="keyword in generatedKeywords.oneGram" :key="keyword">
-                        {{ keyword }}
-                    </li>
-                </ul>
-                <p v-else>No keywords generated.</p>
-            </div>
-
-            <div>
-                <h2>2-Gram</h2>
-                <ul v-if="generatedKeywords.twoGram.length">
-                    <li v-for="keyword in generatedKeywords.twoGram" :key="keyword">
-                        {{ keyword }}
-                    </li>
-                </ul>
-                <p v-else>No keywords generated.</p>
-            </div>
-
-            <div>
-                <h2>3-Gram</h2>
-                <ul v-if="generatedKeywords.threeGram.length">
-                    <li v-for="keyword in generatedKeywords.threeGram" :key="keyword">
+            <div v-for="section in keywordSections" :key="section.title">
+                <h2>{{ section.title }}</h2>
+                <ul v-if="section.keywords.length">
+                    <li v-for="keyword in section.keywords" :key="keyword">
                         {{ keyword }}
                     </li>
                 </ul>

--- a/src/pages/keyword-generator/KeywordGenerator.vue
+++ b/src/pages/keyword-generator/KeywordGenerator.vue
@@ -1,9 +1,111 @@
 <script setup>
+import { ref } from 'vue';
+
+const userInput = ref('');
+const generatedKeywords = ref({
+    oneGram: [],
+    twoGram: [],
+    threeGram: [],
+});
+const hasGenerated = ref(false);
+
+const cleanInput = (input) => input
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+
+const generateUniqueNGrams = (words, gramSize) => {
+    const keywords = [];
+
+    for (let index = 0; index <= words.length - gramSize; index += 1) {
+        keywords.push(words.slice(index, index + gramSize).join(' '));
+    }
+
+    return [...new Set(keywords)];
+};
+
+const generateKeywords = () => {
+    const cleanedInput = cleanInput(userInput.value);
+    const words = cleanedInput ? cleanedInput.split(' ') : [];
+
+    generatedKeywords.value = {
+        oneGram: generateUniqueNGrams(words, 1),
+        twoGram: generateUniqueNGrams(words, 2),
+        threeGram: generateUniqueNGrams(words, 3),
+    };
+    hasGenerated.value = true;
+};
 </script>
+
 <template>
-    <div class="ma-keywords-generator">
-        <div class="ma-header">
-            <span>Keyword Generator</span>
-        </div>
-    </div>
+    <main class="ma-keyword-generator">
+        <h1>Keyword Generator</h1>
+
+        <label for="keyword-input">Text</label>
+        <textarea
+            id="keyword-input"
+            v-model="userInput"
+            class="ma-keyword-input"
+            rows="8"
+            placeholder="Enter text to generate keywords"
+        />
+        <button type="button" @click="generateKeywords">
+            Generate Keywords
+        </button>
+
+        <section v-if="hasGenerated" class="ma-keyword-results" aria-live="polite">
+            <div>
+                <h2>1-Gram</h2>
+                <ul v-if="generatedKeywords.oneGram.length">
+                    <li v-for="keyword in generatedKeywords.oneGram" :key="keyword">
+                        {{ keyword }}
+                    </li>
+                </ul>
+                <p v-else>No keywords generated.</p>
+            </div>
+
+            <div>
+                <h2>2-Gram</h2>
+                <ul v-if="generatedKeywords.twoGram.length">
+                    <li v-for="keyword in generatedKeywords.twoGram" :key="keyword">
+                        {{ keyword }}
+                    </li>
+                </ul>
+                <p v-else>No keywords generated.</p>
+            </div>
+
+            <div>
+                <h2>3-Gram</h2>
+                <ul v-if="generatedKeywords.threeGram.length">
+                    <li v-for="keyword in generatedKeywords.threeGram" :key="keyword">
+                        {{ keyword }}
+                    </li>
+                </ul>
+                <p v-else>No keywords generated.</p>
+            </div>
+        </section>
+    </main>
 </template>
+
+<style scoped>
+.ma-keyword-generator {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 24px;
+}
+
+.ma-keyword-input {
+    display: block;
+    width: 100%;
+    margin: 8px 0 16px;
+    box-sizing: border-box;
+}
+
+.ma-keyword-results {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 24px;
+    margin-top: 24px;
+}
+</style>

--- a/src/pages/keyword-generator/KeywordGenerator.vue
+++ b/src/pages/keyword-generator/KeywordGenerator.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref } from 'vue';
 
+// Store the input and generated keyword groups as reactive state.
 const userInput = ref('');
 const generatedKeywords = ref({
     oneGram: [],
@@ -8,6 +9,8 @@ const generatedKeywords = ref({
     threeGram: [],
 });
 const hasGenerated = ref(false);
+
+// Provide a single data source for rendering each n-gram result section.
 const keywordSections = computed(() => [
     {
         title: '1-Gram',
@@ -23,12 +26,14 @@ const keywordSections = computed(() => [
     },
 ]);
 
+// Normalize the input into lowercase words separated by single spaces.
 const cleanInput = (input) => input
     .toLowerCase()
     .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim()
     .replace(/\s+/g, ' ');
 
+// Build unique consecutive word groups while preserving their original order.
 const generateUniqueNGrams = (words, gramSize) => {
     const keywords = [];
 
@@ -39,6 +44,7 @@ const generateUniqueNGrams = (words, gramSize) => {
     return [...new Set(keywords)];
 };
 
+// Clean the current input and generate the required ONB-201 n-gram groups.
 const generateKeywords = () => {
     const cleanedInput = cleanInput(userInput.value);
     const words = cleanedInput ? cleanedInput.split(' ') : [];
@@ -83,12 +89,14 @@ const generateKeywords = () => {
 </template>
 
 <style scoped>
+/* Keep the generator content centered and comfortably spaced. */
 .ma-keyword-generator {
     max-width: 800px;
     margin: 0 auto;
     padding: 24px;
 }
 
+/* Let the text input fill the available content width. */
 .ma-keyword-input {
     display: block;
     width: 100%;
@@ -96,6 +104,7 @@ const generateKeywords = () => {
     box-sizing: border-box;
 }
 
+/* Arrange the result groups responsively across the available space. */
 .ma-keyword-results {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/src/pages/keyword-generator/KeywordGenerator.vue
+++ b/src/pages/keyword-generator/KeywordGenerator.vue
@@ -8,7 +8,6 @@ const generatedKeywords = ref({
     twoGram: [],
     threeGram: [],
 });
-const hasGenerated = ref(false);
 
 // Provide a single data source for rendering each n-gram result section.
 const keywordSections = computed(() => [
@@ -26,9 +25,14 @@ const keywordSections = computed(() => [
     },
 ]);
 
+const hasGenerated = computed(() => keywordSections.value
+    .some((section) => section.keywords.length > 0));
+
 // Normalize the input into lowercase words separated by single spaces.
 const cleanInput = (input) => input
     .toLowerCase()
+    // \p{L} matches Unicode letters and \p{N} matches Unicode numbers.
+    // This preserves Turkish/non-ASCII text while removing punctuation.
     .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim()
     .replace(/\s+/g, ' ');
@@ -54,7 +58,6 @@ const generateKeywords = () => {
         twoGram: generateUniqueNGrams(words, 2),
         threeGram: generateUniqueNGrams(words, 3),
     };
-    hasGenerated.value = true;
 };
 </script>
 


### PR DESCRIPTION
Implemented the ONB-201 keyword generator inside src/pages/keyword-generator/KeywordGenerator.vue.

This PR adds:

- Text input for user-provided content
- Input cleaning before keyword generation
- Unique 1-gram, 2-gram, and 3-gram keyword generation
- Duplicate removal with Set
- Result sections for each n-gram type
- A small refactor to render keyword sections dynamically with v-for

Implementation details:

- The first commit adds the working ONB-201 functionality.
- The second commit refactors the result rendering by introducing a computed keywordSections array.
- This avoids repeating almost the same template block for 1-Gram, 2-Gram, and 3-Gram sections.

---
I addressed the review feedback.

Changes:
- Derived hasGenerated from generated keyword sections using computed.
- Added a short explanation for the Unicode regex.
- Verified with yarn lint and yarn build.