### PR TITLE
ONB-205: Add Pinia state management

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mobileaction/action-kit": "^1.58.20",
     "ag-grid-community": "^36.0.0",
     "ag-grid-vue3": "^36.0.0",
+    "pinia": "^3.0.4",
     "vue": "^3.5.12",
     "vue-router": "^4.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       ag-grid-vue3:
         specifier: ^36.0.0
         version: 36.0.0(vue@3.5.39)
+      pinia:
+        specifier: ^3.0.4
+        version: 3.0.4(vue@3.5.39)
       vue:
         specifier: ^3.5.12
         version: 3.5.39
@@ -487,6 +490,15 @@ packages:
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
+  '@vue/devtools-api@7.7.10':
+    resolution: {integrity: sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==}
+
+  '@vue/devtools-kit@7.7.10':
+    resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
+
+  '@vue/devtools-shared@7.7.10':
+    resolution: {integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==}
+
   '@vue/reactivity@3.5.39':
     resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
 
@@ -598,6 +610,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -648,6 +663,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
@@ -873,6 +892,9 @@ packages:
       svg2pdf.js:
         optional: true
 
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -919,6 +941,10 @@ packages:
   is-plain-object@3.0.1:
     resolution: {integrity: sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==}
     engines: {node: '>=0.10.0'}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -999,6 +1025,9 @@ packages:
   mitt@2.1.0:
     resolution: {integrity: sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1069,6 +1098,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1083,6 +1115,15 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+
+  pinia@3.0.4:
+    resolution: {integrity: sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+      vue: ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -1163,6 +1204,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -1202,6 +1246,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1214,6 +1262,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1715,6 +1767,24 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
+  '@vue/devtools-api@7.7.10':
+    dependencies:
+      '@vue/devtools-kit': 7.7.10
+
+  '@vue/devtools-kit@7.7.10':
+    dependencies:
+      '@vue/devtools-shared': 7.7.10
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+
+  '@vue/devtools-shared@7.7.10':
+    dependencies:
+      rfdc: 1.4.1
+
   '@vue/reactivity@3.5.39':
     dependencies:
       '@vue/shared': 3.5.39
@@ -1847,6 +1917,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  birpc@2.9.0: {}
+
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.15:
@@ -1900,6 +1972,10 @@ snapshots:
   compute-scroll-into-view@1.0.20: {}
 
   concat-map@0.0.1: {}
+
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
 
   core-js@3.49.0: {}
 
@@ -2148,6 +2224,8 @@ snapshots:
 
   highcharts@12.6.0: {}
 
+  hookable@5.5.3: {}
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -2183,6 +2261,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-object@3.0.1: {}
+
+  is-what@5.5.0: {}
 
   isexe@2.0.0: {}
 
@@ -2248,6 +2328,8 @@ snapshots:
 
   mitt@2.1.0: {}
 
+  mitt@3.0.1: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -2307,6 +2389,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  perfect-debounce@1.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -2314,6 +2398,11 @@ snapshots:
   picomatch@4.0.5: {}
 
   pify@2.3.0: {}
+
+  pinia@3.0.4(vue@3.5.39):
+    dependencies:
+      '@vue/devtools-api': 7.7.10
+      vue: 3.5.39
 
   pirates@4.0.7: {}
 
@@ -2381,6 +2470,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rfdc@1.4.1: {}
+
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
@@ -2438,6 +2529,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  speakingurl@14.0.1: {}
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -2453,6 +2546,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
 
   supports-color@7.2.0:
     dependencies:

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import { ActionKit } from '@mobileaction/action-kit'
 import '@mobileaction/action-kit/dist/style.css'
 import './assets/tailwind.css'
@@ -6,7 +7,9 @@ import App from './App.vue'
 import router from './router'
 
 const app = createApp(App)
+const pinia = createPinia()
 
+app.use(pinia)
 app.use(ActionKit)
 app.use(router)
 

--- a/src/pages/keyword-density/KeywordDensity.vue
+++ b/src/pages/keyword-density/KeywordDensity.vue
@@ -2,8 +2,8 @@
 import { MaButton, MaTextarea } from '@mobileaction/action-kit';
 import { AllCommunityModule, ModuleRegistry } from 'ag-grid-community';
 import { AgGridVue } from 'ag-grid-vue3';
-import { computed, ref } from 'vue';
-import { cleanInput } from '../../utils/keywordUtils';
+import { storeToRefs } from 'pinia';
+import { useKeywordStore } from '../../stores/keywordStore';
 
 // Register Community features only; shared column defaults enable sorting.
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -15,13 +15,21 @@ const props = defineProps({
     },
 });
 
+const store = useKeywordStore();
+
 // Seed local state once so textarea edits remain independent of the parent prop.
-const editableText = ref(props.text);
-// Count every character in the raw textarea value, including whitespace.
-const characterCount = computed(() => editableText.value.length);
-const results = ref([]);
-const hasCounted = ref(false);
-const copyStatus = ref('');
+store.initializeDensityText(props.text);
+
+const {
+    editableText,
+    characterCount,
+    results,
+    hasCounted,
+    copyStatus,
+} = storeToRefs(store);
+
+const { countKeywords, copyResults } = store;
+
 const defaultColDef = {
     sortable: true,
 };
@@ -50,51 +58,6 @@ const columnDefs = [
         valueFormatter: (params) => (params.value != null ? `${params.value.toFixed(1)}%` : ''),
     },
 ];
-
-const countKeywords = () => {
-    hasCounted.value = true;
-    copyStatus.value = '';
-    const cleanedText = cleanInput(editableText.value);
-
-    if (!cleanedText) {
-        results.value = [];
-        return;
-    }
-
-    const words = cleanedText.split(' ');
-    const keywordCounts = words.reduce((counts, keyword) => {
-        counts.set(keyword, (counts.get(keyword) ?? 0) + 1);
-        return counts;
-    }, new Map());
-
-    // Keep one row per keyword for direct sorting in AG Grid.
-    results.value = [...keywordCounts.entries()]
-        .map(([keyword, count]) => ({
-            keywordText: keyword,
-            count,
-            // Density uses every word occurrence, not the number of unique keywords.
-            density: (count / words.length) * 100,
-        }))
-        // Sort keywords by frequency, then alphabetically for stable ties.
-        .sort((firstResult, secondResult) => secondResult.count - firstResult.count
-            || firstResult.keywordText.localeCompare(secondResult.keywordText));
-};
-
-const copyResults = async () => {
-    // Mirror the visible columns in a readable tab-separated clipboard format.
-    const rows = results.value.map(({ keywordText, count, density }) => (
-        `${keywordText}\t${count}\t${density.toFixed(1)}%`
-    ));
-    const clipboardText = ['Keyword\tCount\tDensity', ...rows].join('\n');
-
-    try {
-        await navigator.clipboard.writeText(clipboardText);
-        copyStatus.value = 'Copied to clipboard.';
-    } catch (error) {
-        console.error(error);
-        copyStatus.value = 'Clipboard access is unavailable.';
-    }
-};
 </script>
 
 <template>

--- a/src/pages/keyword-generator/KeywordGenerator.vue
+++ b/src/pages/keyword-generator/KeywordGenerator.vue
@@ -6,17 +6,9 @@ import {
     MaTagInput,
     MaTextarea,
 } from '@mobileaction/action-kit';
-import { computed, ref } from 'vue';
-import { DEFAULT_STOP_WORDS } from '../../constants/stopWords';
-import { cleanInput, generateUniqueNGrams } from '../../utils/keywordUtils';
-
-const userInput = ref('');
-
-// Keep the original ONB-201 result set visible by default while allowing 1–10 selection.
-const selectedGramSizes = ref([1, 2, 3]);
-
-// Start with common words while allowing users to edit the list.
-const unwantedWords = ref(DEFAULT_STOP_WORDS.join(', '));
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useKeywordStore } from '../../stores/keywordStore';
 
 // Define the supported range once so the selector and generation logic cannot drift apart.
 const gramSizeOptions = Array.from({ length: 10 }, (_, index) => index + 1);
@@ -24,81 +16,30 @@ const gramSizeSelectOptions = gramSizeOptions.map((gramSize) => ({
     label: String(gramSize),
     value: gramSize,
 }));
-const generatedKeywords = ref({
-    1: [],
-    2: [],
-    3: [],
+
+const store = useKeywordStore();
+const {
+    keywordSections,
+    hasGenerated,
+    canGenerate,
+    validationMessage,
+} = storeToRefs(store);
+
+const { generateKeywords } = store;
+
+// Use store actions via computed setters to ensure stale results are cleared when inputs change
+const userInput = computed({
+    get: () => store.userInput,
+    set: (value) => store.setUserInput(value),
 });
-
-const keywordSections = computed(() => selectedGramSizes.value
-    .slice()
-    .sort((firstSize, secondSize) => firstSize - secondSize)
-    .map((gramSize) => ({
-        title: `${gramSize}-Gram`,
-        keywords: generatedKeywords.value[gramSize] ?? [],
-    })));
-
-const hasGenerated = computed(() => keywordSections.value
-    .some((section) => section.keywords.length > 0));
-
-// Require a selection so generation cannot run without a visible result section.
-const hasSelectedGramSizes = computed(() => selectedGramSizes.value.length > 0);
-
-const cleanedUserInput = computed(() => cleanInput(userInput.value));
-const hasCleanInput = computed(() => Boolean(cleanedUserInput.value));
-const unwantedWordSet = computed(() => {
-    const cleanedUnwantedWords = cleanInput(unwantedWords.value);
-
-    return new Set(cleanedUnwantedWords ? cleanedUnwantedWords.split(' ') : []);
+const selectedGramSizes = computed({
+    get: () => store.selectedGramSizes,
+    set: (value) => store.setSelectedGramSizes(value),
 });
-const filteredWords = computed(() => (hasCleanInput.value
-    ? cleanedUserInput.value
-        .split(' ')
-        .filter((word) => !unwantedWordSet.value.has(word))
-    : []));
-const currentWordCount = computed(() => filteredWords.value.length);
-
-// The largest selection defines the word count required to generate every selected size.
-const largestSelectedGramSize = computed(() => (hasSelectedGramSizes.value
-    ? Math.max(...selectedGramSizes.value)
-    : 0));
-const hasEnoughWordsForSelectedGrams = computed(() => currentWordCount.value
-    >= largestSelectedGramSize.value);
-
-// Require enough words for the largest selection to avoid partially generated results.
-const canGenerate = computed(() => hasSelectedGramSizes.value
-    && hasCleanInput.value
-    && hasEnoughWordsForSelectedGrams.value);
-const validationMessage = computed(() => {
-    if (!hasCleanInput.value && !hasSelectedGramSizes.value) {
-        return 'Please enter text and select at least one n-gram size.';
-    }
-
-    if (!hasCleanInput.value) {
-        return 'Please enter text to generate keywords.';
-    }
-
-    if (!hasSelectedGramSizes.value) {
-        return 'Please select at least one n-gram size.';
-    }
-
-    return `Please provide at least ${largestSelectedGramSize.value} words after unwanted words are removed.`;
+const unwantedWords = computed({
+    get: () => store.unwantedWords,
+    set: (value) => store.setUnwantedWords(value),
 });
-
-const generateKeywords = () => {
-    // Guard direct calls with the same selection, input, and word-count validation as the button.
-    if (!canGenerate.value) {
-        return;
-    }
-
-    // Intentionally generate all 1–10 sizes so later selection changes never expose stale results.
-    generatedKeywords.value = Object.fromEntries(
-        gramSizeOptions.map((gramSize) => [
-            gramSize,
-            generateUniqueNGrams(filteredWords.value, gramSize),
-        ]),
-    );
-};
 </script>
 
 <template>

--- a/src/stores/keywordStore.js
+++ b/src/stores/keywordStore.js
@@ -1,0 +1,180 @@
+import { defineStore } from 'pinia';
+import { DEFAULT_STOP_WORDS } from '../constants/stopWords';
+import { cleanInput, generateUniqueNGrams } from '../utils/keywordUtils';
+
+export const useKeywordStore = defineStore('keyword', {
+    state: () => ({
+        // Keyword Generator State
+        userInput: '',
+        selectedGramSizes: [1, 2, 3],
+        // Dynamically format input stop words if constant is array, or pass string directly
+        unwantedWords: Array.isArray(DEFAULT_STOP_WORDS)
+            ? DEFAULT_STOP_WORDS.join(', ')
+            : DEFAULT_STOP_WORDS,
+        generatedKeywords: {
+            1: [],
+            2: [],
+            3: [],
+        },
+
+        // Keyword Density State
+        editableText: '',
+        isDensityTextInitialized: false,
+        results: [],
+        hasCounted: false,
+        copyStatus: '',
+    }),
+
+    getters: {
+        // Keyword Generator Derived State
+        cleanedUserInput(state) {
+            return cleanInput(state.userInput);
+        },
+        hasCleanInput() {
+            return Boolean(this.cleanedUserInput);
+        },
+        unwantedWordSet(state) {
+            const cleanedUnwantedWords = cleanInput(state.unwantedWords);
+            return new Set(cleanedUnwantedWords ? cleanedUnwantedWords.split(' ') : []);
+        },
+        filteredWords() {
+            return this.hasCleanInput
+                ? this.cleanedUserInput
+                    .split(' ')
+                    .filter((word) => !this.unwantedWordSet.has(word))
+                : [];
+        },
+        currentWordCount() {
+            return this.filteredWords.length;
+        },
+        hasSelectedGramSizes(state) {
+            return state.selectedGramSizes.length > 0;
+        },
+        largestSelectedGramSize(state) {
+            return this.hasSelectedGramSizes
+                ? Math.max(...state.selectedGramSizes)
+                : 0;
+        },
+        hasEnoughWordsForSelectedGrams() {
+            return this.currentWordCount >= this.largestSelectedGramSize;
+        },
+        canGenerate() {
+            return this.hasSelectedGramSizes
+                && this.hasCleanInput
+                && this.hasEnoughWordsForSelectedGrams;
+        },
+        validationMessage() {
+            if (!this.hasCleanInput && !this.hasSelectedGramSizes) {
+                return 'Please enter text and select at least one n-gram size.';
+            }
+
+            if (!this.hasCleanInput) {
+                return 'Please enter text to generate keywords.';
+            }
+
+            if (!this.hasSelectedGramSizes) {
+                return 'Please select at least one n-gram size.';
+            }
+
+            return `Please provide at least ${this.largestSelectedGramSize} words after unwanted words are removed.`;
+        },
+        keywordSections(state) {
+            return state.selectedGramSizes
+                .slice()
+                .sort((firstSize, secondSize) => firstSize - secondSize)
+                .map((gramSize) => ({
+                    title: `${gramSize}-Gram`,
+                    keywords: state.generatedKeywords[gramSize] ?? [],
+                }));
+        },
+        hasGenerated() {
+            return this.keywordSections.some((section) => section.keywords.length > 0);
+        },
+
+        // Keyword Density Derived State
+        characterCount(state) {
+            return state.editableText.length;
+        },
+    },
+
+    actions: {
+        // Keyword Generator Actions
+        generateKeywords() {
+            if (!this.canGenerate) {
+                return;
+            }
+
+            const gramSizeOptions = Array.from({ length: 10 }, (_, index) => index + 1);
+            this.generatedKeywords = Object.fromEntries(
+                gramSizeOptions.map((gramSize) => [
+                    gramSize,
+                    generateUniqueNGrams(this.filteredWords, gramSize),
+                ]),
+            );
+        },
+        // Missing gram-size keys are read as empty arrays by keywordSections, so an empty object fully clears stale results.
+        clearGeneratedKeywords() {
+            this.generatedKeywords = {};
+        },
+        setUserInput(value) {
+            this.userInput = value;
+            this.clearGeneratedKeywords();
+        },
+        setSelectedGramSizes(value) {
+            this.selectedGramSizes = value;
+            this.clearGeneratedKeywords();
+        },
+        setUnwantedWords(value) {
+            this.unwantedWords = value;
+            this.clearGeneratedKeywords();
+        },
+
+        // Keyword Density Actions
+        initializeDensityText(text) {
+            // Seed the density text only once on first load so subsequent edits are independent of parent prop changes
+            if (this.isDensityTextInitialized) {
+                return;
+            }
+            this.editableText = text;
+            this.isDensityTextInitialized = true;
+        },
+        countKeywords() {
+            this.hasCounted = true;
+            this.copyStatus = '';
+            const cleanedText = cleanInput(this.editableText);
+
+            if (!cleanedText) {
+                this.results = [];
+                return;
+            }
+
+            const words = cleanedText.split(' ');
+            const keywordCounts = words.reduce((counts, keyword) => {
+                counts.set(keyword, (counts.get(keyword) ?? 0) + 1);
+                return counts;
+            }, new Map());
+
+            this.results = [...keywordCounts.entries()]
+                .map(([keyword, count]) => ({
+                    keywordText: keyword,
+                    count,
+                    density: (count / words.length) * 100,
+                }))
+                .sort((firstResult, secondResult) => secondResult.count - firstResult.count
+                    || firstResult.keywordText.localeCompare(secondResult.keywordText));
+        },
+        async copyResults() {
+            const rows = this.results.map(({ keywordText, count, density }) => (
+                `${keywordText}\t${count}\t${density.toFixed(1)}%`
+            ));
+            const clipboardText = ['Keyword\tCount\tDensity', ...rows].join('\n');
+
+            try {
+                await navigator.clipboard.writeText(clipboardText);
+                this.copyStatus = 'Copied to clipboard.';
+            } catch {
+                this.copyStatus = 'Clipboard access is unavailable.';
+            }
+        },
+    },
+});


### PR DESCRIPTION
## Summary
- Added Pinia and registered it in the Vue app
- Created a central keyword store under `src/stores`
- Moved keyword generator state into the store
- Moved keyword density state/results into the store
- Added store getters for derived keyword and density data
- Added store actions for keyword generation, density counting, copy handling, and stale result clearing
- Updated Keyword Generator and Keyword Density pages to read/write through the Pinia store

## Implementation Notes
- This is a pure refactor for ONB-205; no UI/UX or feature behavior was intentionally changed.
- Keyword Generator inputs now update through store actions so generated results are cleared when input text, selected n-grams, or unwanted words change.
- Keyword Density still initializes from the parent `text` prop on first load, then keeps user edits independent from the prop.
- Existing utility functions are still reused for input cleaning and n-gram generation.

## Checks
- `pnpm lint`
- `pnpm build`