### PR TITLE
feat(ai): add copilot agent workflow

### DIFF
--- a/.github/agents/onboarding-reviewer.agent.md
+++ b/.github/agents/onboarding-reviewer.agent.md
@@ -1,0 +1,262 @@
+---
+name: onboarding-reviewer
+description: Review MobileAction onboarding task branches for correctness, scope, verification, and AI-assisted workflow compliance.
+tools: ['search/codebase', 'search/usages']
+---
+
+# Onboarding Reviewer Agent
+
+You are an AI first-pass reviewer for this Vue 3 onboarding repository.
+
+You do not replace human review.
+
+Your job is to help the developer catch issues before opening a PR.
+
+Use these files as project context:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `.github/prompts/plan.prompt.md`
+- `.github/prompts/review.prompt.md`
+- `.github/prompts/reflect.prompt.md`
+- `.github/prompts/e2e-test.prompt.md`
+
+## Step 1 — Determine Task Context
+
+Identify the onboarding task being reviewed.
+
+Check:
+
+- branch name
+- changed files
+- user request
+- task description if available
+
+Expected branch format:
+
+```text
+ONB-<task-number>-YUNUS_GUNAY
+```
+
+Expected onboarding PR target:
+
+```text
+yunus_gunay_onboarding
+```
+
+If the task context is unclear, ask one direct clarification question.
+
+## Step 2 — Check Scope Discipline
+
+Review whether the branch stays focused.
+
+Flag:
+
+- unrelated formatting changes
+- unrelated dependency changes
+- unrelated package or config changes
+- changes that belong to a different onboarding task
+- stale task-specific information added to permanent instructions
+
+A focused branch is preferred over a branch that fixes many unrelated things.
+
+## Step 3 — Review Architecture
+
+Check whether responsibilities are placed correctly.
+
+Use these rules:
+
+- route-level pages belong in `src/pages`
+- reusable components belong in `src/components`
+- pure logic belongs in `src/utils`
+- shared mutable state belongs in `src/stores`
+- Cypress E2E specs belong in `cypress/e2e`
+- reusable AI prompt workflows belong in `.github/prompts`
+- specialized AI agents belong in `.github/agents`
+
+Prefer existing project patterns over new abstractions.
+
+Prefer simple, reviewable changes.
+
+## Step 4 — Review Vue and State Usage
+
+Check:
+
+- Vue 3 Composition API is used.
+- `<script setup>` is used for components.
+- Pinia setup stores are used when shared state is needed.
+- `storeToRefs()` is used when destructuring store state or getters.
+- Store actions are used for business actions.
+- UI-only configuration remains inside components.
+- Reactive state is not destructured in a way that breaks reactivity.
+
+## Step 5 — Review UI and Styling
+
+Check:
+
+- ActionKit components are used where appropriate.
+- Tailwind CSS utility classes are preferred.
+- Custom CSS is avoided unless justified.
+- Layout remains readable.
+- Mobile responsiveness is not obviously broken.
+- UI behavior matches the task requirements.
+
+## Step 6 — Review Tests
+
+Check:
+
+- New user-visible behavior has Cypress coverage.
+- Tests focus on real user behavior.
+- Assertions prove visible outcomes.
+- Exact text matching is used when substring matching could be misleading.
+- Selectors are not unnecessarily brittle.
+- Tests are not coupled to implementation details.
+
+For Cypress changes, verification should include:
+
+```bash
+pnpm lint
+pnpm build
+pnpm test:e2e
+```
+
+## Step 7 — Review Tooling and Dependencies
+
+Check:
+
+- `pnpm` is used.
+- No `package-lock.json` or `yarn.lock` is introduced.
+- New dependencies are justified.
+- Build, lint, and test scripts are scoped and explainable.
+- Configuration changes match the task.
+
+Do not suggest `npm` or `yarn`.
+
+## Step 8 — Review AI Workflow Compliance
+
+For ONB-207 or AI-assisted changes, check:
+
+- `AGENTS.md` provides provider-agnostic guidance.
+- `.github/copilot-instructions.md` provides Copilot-specific guidance.
+- `.github/prompts/` files act as reusable skills.
+- `.github/agents/` files define specialized agents.
+- Unnecessary provider-specific files are not added.
+- AI workflow ideas are adapted to this repository instead of copied directly from another tool.
+- AI usage is disclosed in the PR description.
+- No secrets, credentials, tokens, `.env` values, or private config are included.
+
+## Step 9 — Issue Format
+
+Number each issue.
+
+For every issue, include:
+
+- severity
+- location
+- problem
+- why it matters
+- options when useful
+- recommended fix
+
+Use this severity guide:
+
+### High
+
+Blocks acceptance.
+
+Examples:
+
+- incorrect behavior
+- missing tests for required new behavior
+- wrong PR target
+- secrets or private config included
+- major scope violation
+- AI-generated change that the developer cannot explain
+
+### Medium
+
+Should be fixed if practical.
+
+Examples:
+
+- confusing state ownership
+- brittle test selector
+- weak assertion
+- unnecessary dependency
+- unclear AI disclosure
+- unnecessary abstraction
+
+### Low
+
+Optional improvement.
+
+Examples:
+
+- wording clarity
+- naming consistency
+- minor documentation improvement
+- small readability improvement
+
+## Step 10 — Verdict
+
+Use one of these verdicts:
+
+- **Accept**: no blocking issues, scope is clean, verification is clear
+- **Accept with notes**: only low-severity issues exist
+- **Revise**: high-severity issues exist, or multiple medium issues make the change risky
+
+## Output Format
+
+Use this format:
+
+```md
+## Review Summary
+
+Briefly explain what was reviewed.
+
+## Scope Check
+
+State whether the branch appears focused on the onboarding task.
+
+## Issues
+
+### 1. Severity: high | medium | low
+
+Location:
+
+Problem:
+
+Why it matters:
+
+Options:
+
+A. Recommended option
+- Effort:
+- Risk:
+- Impact:
+- Maintenance:
+
+Recommended fix:
+
+## Verification
+
+List commands that should be run.
+
+## AI Disclosure
+
+Say whether AI usage should be mentioned in the PR description.
+
+## Verdict
+
+Accept, Accept with notes, or Revise.
+```
+
+## Interaction Rules
+
+- Do not edit files.
+- Do not suggest destructive git commands.
+- Do not approve code only because tests pass.
+- Do not invent project conventions.
+- Do not request or expose secrets, credentials, tokens, `.env` values, or private configuration.
+- Present all findings together.
+- Ask for feedback once at the end only if a direction choice is needed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,116 @@
+# GitHub Copilot Instructions
+
+For ONB-207, this repository uses GitHub Copilot as the AI coding agent.
+
+For provider-agnostic project rules, also follow `AGENTS.md`.
+
+## Project Context
+
+This is a Vue 3 frontend onboarding project built with Vite and pnpm.
+
+Main stack:
+
+- Vue 3
+- Vite
+- pnpm
+- Pinia
+- Tailwind CSS
+- ActionKit
+- AG Grid
+- Cypress
+- ESLint
+
+## Commands
+
+Use `pnpm` only.
+
+Common commands:
+
+```bash
+pnpm dev
+pnpm build
+pnpm lint
+pnpm test:e2e
+pnpm test:e2e:open
+```
+
+Do not suggest `npm install`, `npm run`, `yarn`, `package-lock.json`, or `yarn.lock`.
+
+## Code Style
+
+Use Vue 3 Composition API.
+
+Use `<script setup>` for Vue components.
+
+Use Pinia for shared mutable state.
+
+Use `storeToRefs()` for destructured store state and getters.
+
+Keep reusable pure logic in `src/utils`.
+
+Keep UI-only configuration inside components.
+
+Use Tailwind CSS utility classes for styling.
+
+Use ActionKit components where possible.
+
+Prefer clear code over clever abstractions.
+
+## Testing Style
+
+Use Cypress for E2E user-flow tests.
+
+Keep each E2E test focused on one behavior.
+
+Prefer selectors based on visible user-facing behavior:
+
+- page text
+- labels
+- placeholders
+- buttons
+- table content
+
+Avoid brittle DOM selectors unless there is no better option.
+
+For Cypress changes, run:
+
+```bash
+pnpm test:e2e
+```
+
+## Git and PR Rules
+
+Branch format:
+
+```text
+ONB-<task-number>-YUNUS_GUNAY
+```
+
+Open onboarding PRs into:
+
+```text
+yunus_gunay_onboarding
+```
+
+Do not open onboarding PRs directly into `dev`.
+
+Use conventional commits.
+
+Examples:
+
+```text
+feat(keyword-generator): add n-gram generation
+fix(keyword-generator): improve keyword selection UX
+```
+
+## AI Safety Rules
+
+Do not ask for or expose secrets, tokens, credentials, `.env` files, private config, or private company data.
+
+Do not suggest destructive git commands.
+
+Do not make large rewrites without a clear reason.
+
+AI output is only a suggestion. The developer must review, understand, and verify every change.
+
+Human review is still mandatory.

--- a/.github/prompts/e2e-test.prompt.md
+++ b/.github/prompts/e2e-test.prompt.md
@@ -1,0 +1,176 @@
+---
+description: Create or review Cypress E2E tests for user-visible flows.
+---
+
+# E2E Test
+
+Create or review Cypress E2E tests for this Vue 3 onboarding project.
+
+Use `AGENTS.md` and `.github/copilot-instructions.md` as the main project context.
+
+**Focus on user behavior. Do not test implementation details unless there is no practical alternative.**
+
+## Step 1 — Determine the User Flow
+
+Identify the flow being tested.
+
+Examples:
+
+- keyword generation after clicking the generate button
+- n-gram filtering through the multi-select
+- stop-word removal in generated keywords
+- keyword count and density table submission
+- page navigation
+- form interaction
+- visible error or empty-state behavior
+
+If the flow is unclear, ask one direct clarification question.
+
+## Step 2 — Inspect Existing Tests
+
+Before writing a new test, inspect existing Cypress specs:
+
+- `cypress/e2e/keyword-generator.cy.js`
+- `cypress/e2e/keyword-density.cy.js`
+
+Preserve existing style and naming patterns.
+
+Do not duplicate coverage unless the new test checks a distinct behavior.
+
+## Step 3 — Choose Stable Selectors
+
+Prefer user-facing selectors:
+
+- page headings
+- labels
+- placeholders
+- button text
+- visible result text
+- table content
+
+Use commands such as:
+
+```js
+cy.visit();
+cy.get();
+cy.contains();
+cy.type();
+cy.click();
+cy.should();
+```
+
+Avoid brittle selectors based on generated classes, deep DOM structure, or library internals.
+
+Do not add `data-cy` attributes unless the existing UI is too hard to target reliably.
+
+## Step 4 — Write Focused Tests
+
+Each test should cover one user behavior.
+
+A good E2E test should clearly show:
+
+- where the user starts
+- what the user does
+- what visible result proves the feature works
+
+Avoid testing too many behaviors in one `it` block.
+
+Avoid assertions that pass accidentally.
+
+## Step 5 — Assertion Quality
+
+Use exact matching when substring matching could be misleading.
+
+Good:
+
+```js
+cy.contains(/^quick$/).should('exist');
+```
+
+Risky when exact text matters:
+
+```js
+cy.contains('quick').should('exist');
+```
+
+The second version can also match `quick brown`, `quick fox`, or longer text.
+
+For table tests, scope assertions when useful:
+
+```js
+cy.get('.ag-root-wrapper').within(() => {
+    cy.contains(/^fox$/).should('exist');
+    cy.contains(/^2$/).should('exist');
+    cy.contains(/^50%$/).should('exist');
+});
+```
+
+## Step 6 — Edge Cases
+
+Consider whether the flow needs coverage for:
+
+- duplicate words
+- punctuation cleanup
+- uppercase/lowercase normalization
+- Turkish `İ` normalization
+- stop-word removal
+- empty input
+- repeated button clicks
+- selected vs unselected n-gram groups
+- exact keyword matching
+
+Only add edge-case tests that are relevant to the task.
+
+## Step 7 — Verification
+
+For Cypress changes, run:
+
+```bash
+pnpm lint
+pnpm build
+pnpm test:e2e
+```
+
+For debugging, use:
+
+```bash
+pnpm test:e2e:open
+```
+
+## Step 8 — Output Format
+
+Use this format:
+
+```md
+## Flow Covered
+
+Explain the user flow being tested.
+
+## Existing Coverage
+
+Mention whether existing tests already cover related behavior.
+
+## Proposed Test
+
+Provide the Cypress test.
+
+## Why These Assertions Work
+
+Explain what the assertions prove.
+
+## Selector Risk
+
+Mention any selector that may be fragile.
+
+## Verification
+
+List commands to run.
+```
+
+## Interaction Rules
+
+- Do not change application behavior unless explicitly asked.
+- Do not add unnecessary dependencies.
+- Do not suggest `npm` or `yarn`.
+- Do not rely on implementation details when a user-visible selector works.
+- Do not claim the test passes unless it has actually been run.

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -1,0 +1,239 @@
+---
+description: Create a phased implementation plan before coding. Planning only — does not implement.
+---
+
+# Plan
+
+Produce a clear implementation plan grounded in this repository's AI-agent rules.
+
+Use `AGENTS.md` and `.github/copilot-instructions.md` as the main context.
+
+**Do NOT implement anything. The plan is the deliverable.**
+
+## Step 0 — Triage Complexity
+
+Before writing a full plan, assess whether the task actually needs one.
+
+### Trivially small task
+
+If the task affects only 1-2 files and has an obvious approach:
+
+- Say the task probably does not need a full plan.
+- Suggest implementing directly.
+- Stop there.
+- Do not implement.
+
+### Needs planning
+
+Proceed with the full planning workflow if:
+
+- The change spans 3+ files.
+- The change introduces a new pattern, workflow, dependency, or architecture.
+- The task has unclear scope.
+- There are multiple reasonable approaches.
+- The user explicitly asks for a plan.
+
+## Step 1 — Load Project Rules
+
+Read the relevant project guidance before planning:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- related files in the area being changed
+
+Use these rules throughout the plan.
+
+Do not invent project conventions.
+
+Do not use memorized assumptions when repository files are available.
+
+## Step 2 — Define Scope and Constraints
+
+Clarify the task before planning.
+
+Identify:
+
+- what is in scope
+- what is out of scope
+- affected pages, components, stores, utilities, tests, and config files
+- whether new dependencies are needed
+- what "done" means
+- which verification commands are required
+
+If there is blocking ambiguity, ask a direct question with concrete options.
+
+If the request is clear, state the assumed scope and continue.
+
+## Step 3 — Explore Existing Context
+
+Inspect the relevant repository files before proposing changes.
+
+For this project, usually check:
+
+- Vue pages in `src/pages`
+- reusable components in `src/components`
+- pure logic in `src/utils`
+- Pinia stores in `src/stores`
+- Cypress tests in `cypress/e2e`
+- package/config files when dependencies or tooling are affected
+
+For larger tasks, separate the exploration by area:
+
+- UI structure
+- state ownership
+- utility logic
+- tests
+- build/lint configuration
+
+## Step 4 — Check Existing Patterns
+
+Before proposing changes, identify the existing pattern to preserve.
+
+Check whether the task should use:
+
+- Vue 3 Composition API
+- `<script setup>`
+- Pinia setup stores
+- `storeToRefs()`
+- ActionKit components
+- Tailwind CSS utility classes
+- AG Grid community table patterns
+- Cypress E2E user-flow tests
+
+Prefer following existing patterns over introducing new ones.
+
+## Step 5 — Consider Alternatives
+
+For non-trivial design choices, briefly compare 2-3 approaches.
+
+For each approach, mention:
+
+- benefit
+- drawback
+- affected files
+- verification cost
+
+Choose the simplest approach that satisfies the task.
+
+Prefer subtracting complexity before adding new abstractions.
+
+## Step 6 — Write the Plan
+
+Write the plan in phases.
+
+Each phase should be small and reviewable.
+
+Prefer phases that touch only 1-3 files when possible.
+
+Each phase should include:
+
+- goal
+- files affected
+- high-level changes
+- verification
+
+Do not include full code unless the user explicitly asks.
+
+Do not write pseudocode that hides important design choices.
+
+## Step 7 — Verification Strategy
+
+Verification must prove the change works.
+
+For normal code changes, include:
+
+```bash
+pnpm lint
+pnpm build
+```
+
+For Cypress or user-flow changes, include:
+
+```bash
+pnpm lint
+pnpm build
+pnpm test:e2e
+```
+
+For UI changes, also include a manual verification path:
+
+- start the app
+- open the affected page
+- exercise the changed user flow
+- confirm the expected visual result
+
+## Step 8 — Output Format
+
+Use this format:
+
+```md
+## Task Understanding
+
+Summarize the task in one or two sentences.
+
+## Scope
+
+### In Scope
+
+List what should be changed.
+
+### Out of Scope
+
+List what should not be changed.
+
+## Files to Inspect
+
+List files that should be checked before implementation.
+
+## Existing Patterns to Preserve
+
+List relevant project patterns.
+
+## Alternatives Considered
+
+Compare possible approaches if the task is non-trivial.
+
+## Proposed Plan
+
+### Phase 1 — Name
+
+Goal:
+
+Files affected:
+
+Changes:
+
+Verification:
+
+### Phase 2 — Name
+
+Goal:
+
+Files affected:
+
+Changes:
+
+Verification:
+
+## Final Verification
+
+List the commands and manual checks.
+
+## Questions
+
+List only blocking questions. If there are no blocking questions, write `None`.
+```
+
+## Interaction Rules
+
+Do not implement the task.
+
+Do not edit files.
+
+Do not suggest unrelated cleanup.
+
+Do not suggest destructive git commands.
+
+Do not suggest `npm` or `yarn`.
+
+Stop after presenting the plan.

--- a/.github/prompts/reflect.prompt.md
+++ b/.github/prompts/reflect.prompt.md
@@ -1,0 +1,220 @@
+---
+description: Reflect on an AI-assisted development session and suggest reusable repository learnings.
+---
+
+# Reflect
+
+Review the recent AI-assisted development session and extract reusable learnings.
+
+Use `AGENTS.md` and `.github/copilot-instructions.md` as the main project context.
+
+This prompt supports lightweight repository learning without automatically modifying files.
+
+**Do NOT modify files. The reflection is the deliverable unless the user explicitly asks to apply changes.**
+
+## Step 1 — Load Project Context
+
+Read the relevant project guidance first:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- existing `.github/prompts/` files
+- existing `.github/agents/` files
+
+Use these files to understand what is already documented.
+
+Do not suggest duplicate guidance.
+
+Do not rely only on memory if repository files are available.
+
+## Step 2 — Scan the Session
+
+Look for reusable lessons from the conversation or development session.
+
+Focus on:
+
+- mistakes made and corrections received
+- project conventions that became clearer
+- codebase knowledge gained
+- library or tooling quirks discovered
+- decisions made and their rationale
+- AI prompt patterns that worked well
+- AI prompt patterns that caused confusion
+- repeated manual steps that could be encoded
+- verification steps that proved useful
+- places where AI guidance should be safer or more precise
+
+Skip:
+
+- trivial details
+- one-time local issues
+- temporary task-specific facts
+- personal preferences that do not affect the repository
+- anything already captured clearly in existing files
+
+## Step 3 — Route Each Learning
+
+Not every lesson belongs in the same place.
+
+Route each learning to where it has the most value.
+
+### Repository Instructions
+
+Use this route when the lesson should guide all future AI agents.
+
+Possible destinations:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+
+Examples:
+
+- project-wide coding convention
+- branch or PR rule
+- AI safety rule
+- recurring verification rule
+- reusable architecture convention
+
+### Prompt Improvements
+
+Use this route when the lesson improves a reusable skill.
+
+Possible destinations:
+
+- `.github/prompts/plan.prompt.md`
+- `.github/prompts/review.prompt.md`
+- `.github/prompts/reflect.prompt.md`
+- `.github/prompts/e2e-test.prompt.md`
+
+Examples:
+
+- better planning checklist
+- better review checklist
+- better Cypress testing guidance
+- clearer output format
+- missing edge-case instruction
+
+### Agent Improvements
+
+Use this route when the lesson improves a specialized AI role.
+
+Possible destination:
+
+- `.github/agents/onboarding-reviewer.agent.md`
+
+Examples:
+
+- reviewer should check a new category
+- reviewer should avoid a repeated false positive
+- reviewer should use a stricter output format
+- reviewer should better enforce onboarding scope
+
+### Structural Enforcement
+
+Use this route when the lesson should be encoded as tooling instead of documentation.
+
+Examples:
+
+- ESLint rule
+- Cypress test
+- package script
+- build check
+- CI check
+- configuration validation
+
+Prefer structural enforcement over documentation when it would reliably prevent the same issue.
+
+### No Action
+
+Use this route when the lesson is not durable.
+
+Examples:
+
+- one-time command output
+- temporary confusion
+- local setup issue that is already solved
+- information that will become stale quickly
+
+## Step 4 — Check for Contradictions
+
+Before suggesting updates, check whether the new learning conflicts with existing guidance.
+
+Look for contradictions in:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- existing prompt files
+- existing agent files
+- current project code
+
+If there is a conflict:
+
+- explain the conflict
+- recommend which rule should win
+- explain why
+
+## Step 5 — Suggest Updates
+
+Suggest exact updates only when they are useful.
+
+For each suggested update, include:
+
+- target file
+- section
+- reason
+- exact Markdown to add or replace
+
+Keep updates small.
+
+Do not create large new documents.
+
+Do not add a permanent rule just because something happened once.
+
+## Step 6 — Output Format
+
+Use this format:
+
+```md
+## Reflect Summary
+
+Briefly summarize what was learned.
+
+## Durable Lessons
+
+List reusable lessons from the session.
+
+## Suggested Updates
+
+### 1. Target: file path
+
+Section:
+
+Reason:
+
+Change:
+
+Use this format:
+
+    Exact Markdown to add or replace goes here.
+
+## Structural Improvements
+
+List lint, test, script, or config ideas that would enforce lessons better than documentation.
+
+## No-Action Items
+
+List things noticed but intentionally not persisted.
+
+## Questions
+
+List only blocking questions. If there are no blocking questions, write `None`.
+```
+
+## Interaction Rules
+
+- Do not edit files unless the user explicitly asks.
+- Do not store trivial notes.
+- Do not add stale task-specific information to permanent instructions.
+- Do not expose secrets, credentials, tokens, `.env` values, or private configuration.
+- Prefer fewer, higher-quality updates.
+- Explain why each suggested update is worth keeping.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -1,0 +1,313 @@
+---
+description: Review code changes, plans, or PRs for correctness, scope, and project-rule compliance.
+---
+
+# Review
+
+Review code changes, plans, or PRs using this repository's AI-agent rules.
+
+Use `AGENTS.md` and `.github/copilot-instructions.md` as the main project context.
+
+**Do NOT make changes. The review is the deliverable.**
+
+## Step 1 — Load Project Context
+
+Read the relevant project guidance first:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- existing prompt files if relevant
+- existing agent files if relevant
+
+Use these files to ground review judgments.
+
+Do not invent project conventions.
+
+Do not approve a change only because it looks reasonable.
+
+## Step 2 — Determine Review Scope
+
+Infer what should be reviewed from the user request.
+
+Possible review targets:
+
+- current branch diff
+- specific changed files
+- a plan
+- a PR description
+- Cypress tests
+- Vue component changes
+- Pinia store changes
+- utility function changes
+- configuration changes
+- AI workflow files
+
+If the target is genuinely ambiguous, ask one direct clarification question.
+
+Otherwise, state the assumed scope and continue.
+
+## Step 3 — Classify Change Size
+
+Classify the review as small or big.
+
+### Small Change
+
+Use this mode when:
+
+- fewer than 3 files changed
+- no new architecture was introduced
+- behavior is local and easy to inspect
+
+For small changes, keep feedback short and focus on the most important issue in each category.
+
+### Big Change
+
+Use this mode when:
+
+- 3 or more files changed
+- new architecture or workflow was introduced
+- new dependencies were added
+- state management changed
+- tests or configuration changed across multiple areas
+
+For big changes, review by category and be stricter about scope, verification, and maintainability.
+
+## Step 4 — Gather Context
+
+Inspect the files needed to understand the change.
+
+Common files to check:
+
+- changed Vue files
+- changed Pinia stores
+- changed utilities
+- changed Cypress specs
+- `package.json`
+- config files changed by the branch
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+
+For task branches, check whether the changes match the onboarding task scope.
+
+Do not review files in isolation when related files are necessary to understand behavior.
+
+## Step 5 — Assessment Pipeline
+
+Work through these sections in order.
+
+### 1. Scope Check
+
+Check:
+
+- Does the change match the onboarding task?
+- Are unrelated files changed?
+- Is the branch name consistent with `ONB-<task-number>-YUNUS_GUNAY`?
+- Should the PR target `yunus_gunay_onboarding`?
+- Are task-specific changes kept out of permanent instructions when they would become stale?
+
+### 2. Architecture
+
+Check:
+
+- Are responsibilities placed in the correct layer?
+- Is shared mutable state placed in Pinia when needed?
+- Is UI-only configuration kept inside components?
+- Are utility functions pure and reusable?
+- Are new abstractions necessary?
+- Is the solution simpler than the alternatives?
+- Does the change preserve existing project patterns?
+
+### 3. Vue and State Quality
+
+Check:
+
+- Vue 3 Composition API is used.
+- `<script setup>` is used.
+- `storeToRefs()` is used when destructuring store state or getters.
+- Store actions are used for business actions.
+- Reactive state is not accidentally destructured incorrectly.
+- Component code remains readable.
+
+### 4. UI and Styling
+
+Check:
+
+- ActionKit components are used where appropriate.
+- Tailwind CSS utility classes are preferred.
+- Custom CSS is avoided unless justified.
+- Layout remains readable and responsive.
+- UI behavior matches user expectations.
+
+### 5. Cypress and Tests
+
+Check:
+
+- New user-visible behavior has E2E coverage.
+- Tests assert outcomes, not implementation details.
+- Selectors are reasonably stable.
+- Exact text assertions are used when substring matches could be misleading.
+- Tests are focused and readable.
+- `pnpm test:e2e` should pass for Cypress or user-flow changes.
+
+### 6. Tooling and Dependencies
+
+Check:
+
+- `pnpm` is used.
+- No `package-lock.json` or `yarn.lock` is introduced.
+- New dependencies are justified.
+- Build and lint commands are updated only when needed.
+- Configuration changes are scoped and explainable.
+
+### 7. AI Safety
+
+Check:
+
+- No secrets, credentials, tokens, `.env` values, or private config are included.
+- AI usage is disclosed when it meaningfully changed code, tests, or repository configuration.
+- The developer can explain the change.
+- Human review is still required.
+- AI-generated suggestions are not treated as automatically correct.
+
+## Step 6 — Issue Format
+
+Number each issue.
+
+For every issue, include:
+
+- severity
+- location
+- problem
+- why it matters
+- options
+- recommended fix
+
+Use this severity guide:
+
+### High
+
+Blocks acceptance.
+
+Examples:
+
+- incorrect behavior
+- missing tests for required new behavior
+- unrelated risky changes
+- secrets or private config included
+- wrong PR target
+- major scope violation
+
+### Medium
+
+Should be fixed if practical.
+
+Examples:
+
+- confusing state ownership
+- avoidable duplication
+- weak test assertion
+- brittle selector
+- unnecessary dependency
+- unclear AI disclosure
+
+### Low
+
+Optional improvement.
+
+Examples:
+
+- minor wording issue
+- small readability improvement
+- documentation clarity
+- naming consistency
+
+## Step 7 — Options Format
+
+When giving a fix, provide options if there is more than one reasonable path.
+
+Use this format:
+
+```md
+Options:
+
+A. Recommended option
+- Effort:
+- Risk:
+- Impact:
+- Maintenance:
+
+B. Alternative option
+- Effort:
+- Risk:
+- Impact:
+- Maintenance:
+```
+
+If there is only one obvious fix, provide only the recommended fix.
+
+## Step 8 — Verdict
+
+End with one verdict.
+
+Use:
+
+- **Accept**: no blocking issues, scope is clean, verification is clear
+- **Accept with notes**: only low-severity issues exist
+- **Revise**: high-severity issues exist, or multiple medium issues make the change risky
+
+## Step 9 — Output Format
+
+Use this format:
+
+```md
+## Review Summary
+
+Briefly explain what was reviewed.
+
+## Scope Check
+
+State whether the change appears focused on the task.
+
+## Issues
+
+### 1. Severity: high | medium | low
+
+Location:
+
+Problem:
+
+Why it matters:
+
+Options:
+
+A. Recommended option
+- Effort:
+- Risk:
+- Impact:
+- Maintenance:
+
+Recommended fix:
+
+## Verification
+
+List commands that should be run.
+
+## AI Disclosure
+
+Say whether AI usage should be mentioned in the PR description.
+
+## Verdict
+
+Accept, Accept with notes, or Revise.
+```
+
+## Interaction Rules
+
+- Do not edit files.
+- Do not suggest destructive git commands.
+- Do not approve code only because tests pass.
+- Do not invent project conventions.
+- Do not request or expose secrets, credentials, tokens, `.env` values, or private configuration.
+- When uncertain, say what needs to be checked.
+- Present all findings together.
+- Ask for feedback once at the end if a direction choice is needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,285 @@
+# AGENTS.md
+
+## Purpose
+
+This file provides provider-agnostic instructions for AI coding agents working in this repository.
+
+Provider-specific files may exist, but this file contains the shared project rules that should stay useful across different AI tools.
+
+## Project Overview
+
+This repository is a Vue 3 frontend onboarding project.
+
+The project teaches:
+
+- Vue 3 component-based development
+- Utility-first frontend structure
+- Pinia state management
+- Cypress E2E testing
+- Code review and PR workflow
+- Responsible AI-assisted development
+
+## Tech Stack
+
+- Vue 3
+- Vite
+- pnpm
+- Pinia
+- Tailwind CSS
+- ActionKit
+- AG Grid
+- Cypress
+- ESLint
+
+Use `pnpm` only. Do not use `npm` or `yarn`.
+
+## Essential Commands
+
+Install dependencies:
+
+```bash
+pnpm install
+```
+
+Start the development server:
+
+```bash
+pnpm dev
+```
+
+Build the project:
+
+```bash
+pnpm build
+```
+
+Run linting:
+
+```bash
+pnpm lint
+```
+
+Run Cypress E2E tests headlessly:
+
+```bash
+pnpm test:e2e
+```
+
+Open Cypress interactively:
+
+```bash
+pnpm test:e2e:open
+```
+
+## Repository Structure
+
+Important folders:
+
+- `src/pages` contains route-level Vue pages.
+- `src/components` contains reusable Vue components.
+- `src/utils` contains pure utility functions.
+- `src/stores` contains Pinia stores.
+- `cypress/e2e` contains Cypress E2E tests.
+- `.github/prompts` contains reusable AI prompt workflows.
+- `.github/agents` contains specialized AI agent definitions.
+
+Important files:
+
+- `src/utils/CleanDescription.js` normalizes input text.
+- `src/utils/GenerateNGrams.js` generates n-grams and removes stop words.
+- `src/stores/keyword.js` stores keyword-generator and keyword-density state.
+- `src/pages/keyword-generator/KeywordGenerator.vue` contains the keyword generator UI.
+- `src/components/KeywordDensity.vue` contains the keyword density UI and AG Grid table.
+- `cypress/e2e/keyword-generator.cy.js` tests keyword generation flows.
+- `cypress/e2e/keyword-density.cy.js` tests keyword density flows.
+
+## Vue Guidelines
+
+Use Vue 3 Composition API.
+
+Use `<script setup>` in Vue components.
+
+Use Pinia for shared mutable state.
+
+Use `storeToRefs()` when destructuring reactive state or getters from a Pinia store.
+
+Actions can be destructured directly from the store.
+
+Example:
+
+```js
+const keywordStore = useKeywordStore();
+
+const {
+    generatorInputText,
+    selectedNGrams,
+    generatedKeywords
+} = storeToRefs(keywordStore);
+
+const { generateKeywords } = keywordStore;
+```
+
+## State Management Guidelines
+
+Put shared mutable application state in Pinia stores.
+
+Good store state examples:
+
+- input text that should persist while navigating
+- selected n-grams
+- generated keyword results
+- keyword density table rows
+
+Keep UI-only configuration inside components.
+
+Good component-only examples:
+
+- AG Grid column definitions
+- AG Grid modules
+- static select options
+- layout classes
+
+## Utility Guidelines
+
+Keep reusable business logic in `src/utils`.
+
+Utility functions should be pure when possible.
+
+A utility function should not depend on Vue component state, DOM state, or browser interaction.
+
+Examples:
+
+- cleaning text
+- generating n-grams
+- removing stop words
+- calculating derived keyword data
+
+## Cypress Guidelines
+
+Cypress tests should cover real user flows.
+
+Prefer testing what a user does and sees:
+
+- visit a page
+- type text
+- click a button
+- select options
+- verify visible output
+
+Use Cypress commands such as:
+
+- `cy.visit()`
+- `cy.get()`
+- `cy.contains()`
+- `.type()`
+- `.click()`
+- `.should()`
+
+Keep each test focused on one behavior.
+
+Avoid testing implementation details unless there is no practical user-facing selector.
+
+## Styling Guidelines
+
+Use Tailwind CSS utility classes.
+
+Prefer ActionKit components for UI consistency.
+
+Avoid custom CSS in Vue files unless Tailwind cannot reasonably express the style.
+
+## Branch and PR Workflow
+
+Create one branch per onboarding task.
+
+Branch format:
+
+```text
+ONB-<task-number>-YUNUS_GUNAY
+```
+
+Example:
+
+```text
+ONB-207-YUNUS_GUNAY
+```
+
+Open onboarding PRs into:
+
+```text
+yunus_gunay_onboarding
+```
+
+Do not open onboarding PRs directly into `dev`.
+
+Before pushing, run the relevant checks.
+
+For normal code changes:
+
+```bash
+pnpm lint
+pnpm build
+```
+
+For Cypress or user-flow changes:
+
+```bash
+pnpm lint
+pnpm build
+pnpm test:e2e
+```
+
+## Commit Rules
+
+Use conventional commit messages.
+
+Examples:
+
+```text
+feat(keyword-generator): add n-gram generation
+fix(keyword-generator): improve keyword selection UX
+```
+
+Keep commits small and focused.
+
+Do not include unrelated changes in a task branch.
+
+## AI Usage Rules
+
+The developer owns every line of AI-assisted code.
+
+AI suggestions must be reviewed, understood, and tested before committing.
+
+AI may be used for:
+
+- explaining code
+- suggesting small refactors
+- reviewing diffs
+- drafting tests
+- improving documentation
+- identifying possible edge cases
+
+AI must not be used for:
+
+- committing code the developer cannot explain
+- bypassing failing checks
+- replacing human review
+- pasting secrets, tokens, credentials, `.env` values, or private configuration
+- making large unreviewed rewrites
+
+If AI meaningfully changes code, tests, or repository configuration, disclose that usage in the PR description.
+
+## Agent Operating Principles
+
+Prefer understanding before editing.
+
+Keep changes small and reviewable.
+
+Ask for clarification when task scope is ambiguous.
+
+Do not hide uncertainty.
+
+Do not invent project conventions.
+
+Follow the existing code style.
+
+Explain what changed and why it is correct.


### PR DESCRIPTION
Copilot-based AI workflow for ONB-207, inspired by [brainmaxxing](https://github.com/poteto/brainmaxxing) but adapted to this project’s `.github` structure.

The mapping is: `AGENTS.md` provides shared provider-agnostic context, `.github/copilot-instructions.md` provides Copilot-specific instructions.

`.github/prompts/*` acts as reusable skills for planning, review, reflection, and E2E testing, and `.github/agents/onboarding-reviewer.agent.md` defines a specialized first-pass reviewer for onboarding branches.